### PR TITLE
Fix placeholder compatibility issue

### DIFF
--- a/src/SelectAutoComplete.php
+++ b/src/SelectAutoComplete.php
@@ -90,7 +90,7 @@ class SelectAutoComplete extends Select
         return $this->withMeta([__FUNCTION__ => $this->displayUsingLabels]);
     }
 
-    public function placeholder(string $placeholer)
+    public function placeholder($placeholer)
     {
         if ($placeholer) {
             $this->placeholder = trim($placeholer);


### PR DESCRIPTION
Fixes "Declaration of Techouse\SelectAutoComplete\SelectAutoComplete::placeholder(string $placeholer) should be compatible with Laravel\Nova\Fields\Field::placeholder($text)" error